### PR TITLE
add:#39 パスワードリセットAPIの実装

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -11,4 +11,6 @@ const (
 	TokenExpiration_m int = 60
 	// JWT側の最大有効期限（連続操作この指定時間経てば期限が切れる）
 	MaxTokenExpiration_m int = 3600
+	// ランダムパスワードの桁数
+	RandomPasswordLength int = 12
 )

--- a/domain/interface.go
+++ b/domain/interface.go
@@ -12,6 +12,7 @@ import (
 type UserRepo interface {
 	FindUserByEmail(ctx context.Context, db repository.Queryer, e *string) (entity.User, error)
 	RegisterUser(ctx context.Context, db repository.Execer, u *entity.User) error
+	UpdatePassword(ctx context.Context, db repository.Execer, email, pass *string) error
 }
 
 // トークンに対するインターフェース

--- a/domain/user/password.go
+++ b/domain/user/password.go
@@ -58,3 +58,10 @@ func (pwd *Password) CreateRandomPassword() *Password {
 	}
 	return &Password{value: string(value)}
 }
+
+// 文字列
+// @return
+// パスワード
+func (pwd *Password) String() string {
+	return string(pwd.value)
+}

--- a/domain/user/password.go
+++ b/domain/user/password.go
@@ -2,8 +2,11 @@ package user
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 	"unicode/utf8"
 
+	"github.com/hack-31/point-app-backend/constant"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -27,7 +30,7 @@ func NewPasswrod(pwd string) (*Password, error) {
 }
 
 // ハッシュ化されたパスワードと一致するか
-// @params 
+// @params
 // hashPwd ハッシュ化されたパスワード
 func (pwd *Password) IsMatch(hashPwd string) (bool, error) {
 	err := bcrypt.CompareHashAndPassword([]byte(hashPwd), []byte(pwd.value))
@@ -40,4 +43,18 @@ func (pwd *Password) IsMatch(hashPwd string) (bool, error) {
 func (pwd *Password) CreateHash() (string, error) {
 	pw, err := bcrypt.GenerateFromPassword([]byte(pwd.value), bcrypt.DefaultCost)
 	return string(pw), err
+}
+
+// ラムダム文字列のパスワードを作成
+func (pwd *Password) CreateRandomPassword() *Password {
+	// どの文字列からランダム文字列を生成するか
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	rand.Seed(time.Now().UnixNano())
+	value := make([]byte, constant.RandomPasswordLength)
+	for i := range value {
+		r := rand.Int63() % int64(len(letters))
+		value[i] = letters[int(r)]
+	}
+	return &Password{value: string(value)}
 }

--- a/handler/reset_password.go
+++ b/handler/reset_password.go
@@ -46,10 +46,6 @@ func (s *ResetPassword) ServeHTTP(ctx *gin.Context) {
 
 	// パスワード再発行処理依頼
 	if err := s.Service.ResetPassword(ctx, input.Email); err != nil {
-		if errors.Is(err, repository.ErrNotFoundSession) {
-			ErrResponse(ctx, http.StatusUnauthorized, errTitle, repository.ErrNotFoundSession.Error())
-			return
-		}
 		if errors.Is(err, repository.ErrNotExistEmail) {
 			ErrResponse(ctx, http.StatusNotFound, errTitle, repository.ErrNotExistEmail.Error())
 			return

--- a/handler/reset_password.go
+++ b/handler/reset_password.go
@@ -27,7 +27,7 @@ func (s *ResetPassword) ServeHTTP(ctx *gin.Context) {
 		Email string `json:"email"`
 	}
 
-	const errTitle = "パスワード再発行エラー"
+	const errTitle = "パスワードリセットエラー"
 	if err := ctx.ShouldBindJSON(&input); err != nil {
 		ErrResponse(ctx, http.StatusBadRequest, errTitle, err.Error())
 		return
@@ -48,6 +48,10 @@ func (s *ResetPassword) ServeHTTP(ctx *gin.Context) {
 	if err := s.Service.ResetPassword(ctx, input.Email); err != nil {
 		if errors.Is(err, repository.ErrNotFoundSession) {
 			ErrResponse(ctx, http.StatusUnauthorized, errTitle, repository.ErrNotFoundSession.Error())
+			return
+		}
+		if errors.Is(err, repository.ErrNotExistEmail) {
+			ErrResponse(ctx, http.StatusNotFound, errTitle, repository.ErrNotExistEmail.Error())
 			return
 		}
 		ErrResponse(ctx, http.StatusInternalServerError, errTitle, err.Error())

--- a/handler/reset_password.go
+++ b/handler/reset_password.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/hack-31/point-app-backend/repository"
+)
+
+type ResetPassword struct {
+	Service ResetPasswordService
+}
+
+func NewResetPasswordHandler(s ResetPasswordService) *ResetPassword {
+	return &ResetPassword{Service: s}
+}
+
+// サインアウトハンドラー
+//
+// @param ctx ginContext
+func (s *ResetPassword) ServeHTTP(ctx *gin.Context) {
+	// ユーザのパラメータ検証
+	var input struct {
+		Email string `json:"email"`
+	}
+
+	const errTitle = "パスワード再発行エラー"
+	if err := ctx.ShouldBindJSON(&input); err != nil {
+		ErrResponse(ctx, http.StatusBadRequest, errTitle, err.Error())
+		return
+	}
+	if err := validation.ValidateStruct(&input,
+		validation.Field(
+			&input.Email,
+			validation.Length(1, 256),
+			validation.Required,
+			is.Email,
+		),
+	); err != nil {
+		ErrResponse(ctx, http.StatusBadRequest, errTitle, err.Error())
+		return
+	}
+
+	// パスワード再発行処理依頼
+	if err := s.Service.ResetPassword(ctx, input.Email); err != nil {
+		if errors.Is(err, repository.ErrNotFoundSession) {
+			ErrResponse(ctx, http.StatusUnauthorized, errTitle, repository.ErrNotFoundSession.Error())
+			return
+		}
+		ErrResponse(ctx, http.StatusInternalServerError, errTitle, err.Error())
+		return
+	}
+
+	APIResponse(ctx, http.StatusCreated, "パスワード再発行メールを送信しました。", nil)
+}

--- a/handler/service.go
+++ b/handler/service.go
@@ -21,3 +21,7 @@ type SigninService interface {
 type SignoutService interface {
 	Signout(ctx context.Context, userId string) error
 }
+
+type ResetPasswordService interface {
+	ResetPassword(ctx context.Context, email string) error
+}

--- a/repository/error.go
+++ b/repository/error.go
@@ -13,6 +13,7 @@ const (
 
 var (
 	ErrAlreadyEntry    = errors.New("登録済みのメールアドレスは登録できません。")
+	ErrNotExistEmail   = errors.New("メールアドレスが存在しません。")
 	ErrNotFoundSession = errors.New("確認コードまたは、セッションキーが無効です。")
 	ErrNotMatchLogInfo = errors.New("メールアドレスまたは、パスワードが異なります。")
 )

--- a/repository/user.go
+++ b/repository/user.go
@@ -60,3 +60,22 @@ func (r *Repository) FindUserByEmail(ctx context.Context, db Queryer, email *str
 	}
 	return user, nil
 }
+
+// パスワードを上書き
+// @params
+// ctx context
+// db dbインスタンス
+// email email
+// pass password
+//
+// @returns
+// error
+func (r *Repository) UpdatePassword(ctx context.Context, db Execer, email, pass *string) error {
+	sql := `UPDATE users SET password = ? WHERE email = ?`
+
+	_, err := db.ExecContext(ctx, sql, pass, email)
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/router/router.go
+++ b/router/router.go
@@ -54,5 +54,8 @@ func SetRouting(ctx context.Context, db *sqlx.DB, router *gin.Engine, cfg *confi
 	signout := handler.NewSignoutHandler(&service.Signout{Cache: tokenCache})
 	groupRoute.DELETE("/tokens/:userId", signout.ServeHTTP)
 
+	resetPassword := handler.NewResetPasswordHandler(&service.ResetPassword{ExecerDB: db, QueryerDB: db, Repo: &rep})
+	groupRoute.PATCH("/random_password", resetPassword.ServeHTTP)
+
 	return nil
 }

--- a/service/reset_password.go
+++ b/service/reset_password.go
@@ -36,7 +36,7 @@ func (rp *ResetPassword) ResetPassword(ctx context.Context, email string) error 
 		return err
 	}
 	if !existMail {
-		return fmt.Errorf("not exist email address: %w", repository.ErrAlreadyEntry)
+		return fmt.Errorf("not exist email address: %w", repository.ErrNotExistEmail)
 	}
 
 	pass, err := user.NewPasswrod("")

--- a/service/reset_password.go
+++ b/service/reset_password.go
@@ -60,7 +60,7 @@ func (rp *ResetPassword) ResetPassword(ctx context.Context, email string) error 
 
 	// メール送信
 	subject := "【ポイントアプリ】パスワード再発行完了のお知らせ"
-	body := fmt.Sprintf("ポイントアプリをご利用いただきありがとうございます。\n\nポイントアプリのパスワード再設定が完了しました。\n新しいパスワードは %s です。", randomPass)
+	body := fmt.Sprintf("ポイントアプリをご利用いただきありがとうございます。\n\nポイントアプリのパスワード再設定が完了しました。\n新しいパスワードは %s です。", randomPass.String())
 	_, err = utils.SendMail(email, subject, body)
 	if err != nil {
 		return fmt.Errorf("failed to send email: %w", err)

--- a/service/reset_password.go
+++ b/service/reset_password.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hack-31/point-app-backend/domain"
+	"github.com/hack-31/point-app-backend/domain/user"
+	"github.com/hack-31/point-app-backend/repository"
+	utils "github.com/hack-31/point-app-backend/utils/email"
+)
+
+type ResetPassword struct {
+	ExecerDB  repository.Execer
+	QueryerDB repository.Queryer
+	Repo      domain.UserRepo
+}
+
+// パスワードリセットサービス
+//
+// @params
+// email メールアドレス
+//
+// @returns
+// error
+func (rp *ResetPassword) ResetPassword(ctx context.Context, email string) error {
+	// メール値オブジェクト作成
+	mail, err := user.NewEmail(email, rp.Repo)
+	if err != nil {
+		return fmt.Errorf("cannot create mail object: %w", err)
+	}
+
+	// 登録可能なメールか確認
+	existMail, err := mail.Exist(ctx, &rp.QueryerDB)
+	if err != nil {
+		return err
+	}
+	if !existMail {
+		return fmt.Errorf("not exist email address: %w", repository.ErrAlreadyEntry)
+	}
+
+	pass, err := user.NewPasswrod("")
+	if err != nil {
+		return fmt.Errorf("cannot create passwrod object: %w", err)
+	}
+
+	// ランダムパスワードを生成
+	randomPass := pass.CreateRandomPassword()
+
+	// パスワードハッシュ化
+	hashPass, err := randomPass.CreateHash()
+	if err != nil {
+		return fmt.Errorf("cannot create hash passwrod: %w", err)
+	}
+
+	// パスワードを上書き
+	if err := rp.Repo.UpdatePassword(ctx, rp.ExecerDB, &email, &hashPass); err != nil {
+		return fmt.Errorf("failed to update password: %w", err)
+	}
+
+	// メール送信
+	subject := "【ポイントアプリ】パスワード再発行完了のお知らせ"
+	body := fmt.Sprintf("ポイントアプリをご利用いただきありがとうございます。\n\nポイントアプリのパスワード再設定が完了しました。\n新しいパスワードは %s です。", randomPass)
+	_, err = utils.SendMail(email, subject, body)
+	if err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# issue
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #39 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- パスワードリセットAPI PATCH (/password_reset)の実装
- ランダムパスワードを生成
- リクエストされたemailユーザーのパスワードをそのランダムパスワードに書き換える
- 登録されているメールアドレスに変更後のパスワードを送信する

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
