### PR TITLE
Feature/#95 未読お知らせ数通知API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,13 @@ moq: ## Generate mock
 					GetUncheckedNotificationCountService
 
 	# リポジトリのモック生成
-	moq -out ./service/moq_test.go -skip-ensure -pkg service ./domain \
+	moq -fmt goimports -out ./service/moq_test.go -skip-ensure -pkg service ./domain \
 					Cache \
 					TokenGenerator \
 					UserRepo \
 					PointRepo \
 					NotificationRepo
-	moq -out ./service/repogitory_moq_test.go -skip-ensure -pkg service ./repository Beginner Preparer Execer Queryer Transacter
+	moq -fmt goimports -out ./service/repogitory_moq_test.go -skip-ensure -pkg service ./repository Beginner Preparer Execer Queryer Transacter
 
 
 test: ## テスト

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ moq: ## Generate mock
 					GetAccountService \
 					UpdateTemporaryEmailService \
 					GetNotificationService \
-					GetNotificationsService 
+					GetNotificationsService \
+					GetUncheckedNotificationCountService
 
 	# リポジトリのモック生成
 	moq -out ./service/moq_test.go -skip-ensure -pkg service ./domain \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
     tty: true
     ports:
       - 8081:80
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
   doc:
     image: swaggerapi/swagger-ui:latest
     container_name: doc
@@ -50,6 +55,10 @@ services:
       - $PWD/_tools/mysql/conf.d:/etc/mysql/conf.d:cached
     ports:
       - "33306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
   cache:
     image: "redis:latest"
     container_name: point-app-redis
@@ -57,6 +66,11 @@ services:
       - "36379:6379"
     volumes:
       - point-app-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 30s
+      retries: 30
   panel:
     image: "adminer:latest"
     restart: always

--- a/handler/get_unchecked_notification_count.go
+++ b/handler/get_unchecked_notification_count.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+)
+
+type GetUncheckedNotificationCount struct {
+	Service GetUncheckedNotificationCountService
+}
+
+func NewGetUncheckedNotificationCount(s GetUncheckedNotificationCountService) *GetUncheckedNotificationCount {
+	return &GetUncheckedNotificationCount{Service: s}
+}
+
+// お知らせ数取得ハンドラー
+//
+// @param ctx ginContext
+func (gunc *GetUncheckedNotificationCount) ServeHTTP(ctx *gin.Context) {
+	// ヘッダー情報設定
+	ctx.Header("Content-Type", "text/event-stream")
+	ctx.Header("Cache-Control", "no-cache")
+	ctx.Header("Connection", "keep-alive")
+
+	notificationCntChan := make(chan int)
+	defer close(notificationCntChan)
+
+	//　初回お知らせ数の返却
+	cnt, err := gunc.Service.GetUncheckedNotificationCount(ctx, notificationCntChan)
+	if err != nil {
+		ctx.SSEvent("error", err.Error())
+		ctx.Writer.Flush()
+		return
+	}
+	res := struct {
+		Count int `json:"count"`
+	}{
+		Count: cnt,
+	}
+	jsonData, err := json.Marshal(res)
+	if err != nil {
+		ctx.SSEvent("error", err.Error())
+		ctx.Writer.Flush()
+		return
+	}
+	ctx.SSEvent("message", string(jsonData))
+	ctx.Writer.Flush()
+
+	// お知らせ通知を待機
+	for {
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		case cnt := <-notificationCntChan:
+			res := struct {
+				Count int `json:"count"`
+			}{
+				Count: cnt,
+			}
+			jsonData, err := json.Marshal(res)
+			if err != nil {
+				ctx.SSEvent("error", err.Error())
+				ctx.Writer.Flush()
+				return
+			}
+			ctx.SSEvent("message", string(jsonData))
+			ctx.Writer.Flush()
+		}
+	}
+}

--- a/handler/moq_test.go
+++ b/handler/moq_test.go
@@ -1007,3 +1007,75 @@ func (mock *GetNotificationsServiceMock) GetNotificationsCalls() []struct {
 	mock.lockGetNotifications.RUnlock()
 	return calls
 }
+
+// Ensure, that GetUncheckedNotificationCountServiceMock does implement GetUncheckedNotificationCountService.
+// If this is not the case, regenerate this file with moq.
+var _ GetUncheckedNotificationCountService = &GetUncheckedNotificationCountServiceMock{}
+
+// GetUncheckedNotificationCountServiceMock is a mock implementation of GetUncheckedNotificationCountService.
+//
+//	func TestSomethingThatUsesGetUncheckedNotificationCountService(t *testing.T) {
+//
+//		// make and configure a mocked GetUncheckedNotificationCountService
+//		mockedGetUncheckedNotificationCountService := &GetUncheckedNotificationCountServiceMock{
+//			GetUncheckedNotificationCountFunc: func(ctx *gin.Context, notificationCntChan chan<- int) (int, error) {
+//				panic("mock out the GetUncheckedNotificationCount method")
+//			},
+//		}
+//
+//		// use mockedGetUncheckedNotificationCountService in code that requires GetUncheckedNotificationCountService
+//		// and then make assertions.
+//
+//	}
+type GetUncheckedNotificationCountServiceMock struct {
+	// GetUncheckedNotificationCountFunc mocks the GetUncheckedNotificationCount method.
+	GetUncheckedNotificationCountFunc func(ctx *gin.Context, notificationCntChan chan<- int) (int, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetUncheckedNotificationCount holds details about calls to the GetUncheckedNotificationCount method.
+		GetUncheckedNotificationCount []struct {
+			// Ctx is the ctx argument value.
+			Ctx *gin.Context
+			// NotificationCntChan is the notificationCntChan argument value.
+			NotificationCntChan chan<- int
+		}
+	}
+	lockGetUncheckedNotificationCount sync.RWMutex
+}
+
+// GetUncheckedNotificationCount calls GetUncheckedNotificationCountFunc.
+func (mock *GetUncheckedNotificationCountServiceMock) GetUncheckedNotificationCount(ctx *gin.Context, notificationCntChan chan<- int) (int, error) {
+	if mock.GetUncheckedNotificationCountFunc == nil {
+		panic("GetUncheckedNotificationCountServiceMock.GetUncheckedNotificationCountFunc: method is nil but GetUncheckedNotificationCountService.GetUncheckedNotificationCount was just called")
+	}
+	callInfo := struct {
+		Ctx                 *gin.Context
+		NotificationCntChan chan<- int
+	}{
+		Ctx:                 ctx,
+		NotificationCntChan: notificationCntChan,
+	}
+	mock.lockGetUncheckedNotificationCount.Lock()
+	mock.calls.GetUncheckedNotificationCount = append(mock.calls.GetUncheckedNotificationCount, callInfo)
+	mock.lockGetUncheckedNotificationCount.Unlock()
+	return mock.GetUncheckedNotificationCountFunc(ctx, notificationCntChan)
+}
+
+// GetUncheckedNotificationCountCalls gets all the calls that were made to GetUncheckedNotificationCount.
+// Check the length with:
+//
+//	len(mockedGetUncheckedNotificationCountService.GetUncheckedNotificationCountCalls())
+func (mock *GetUncheckedNotificationCountServiceMock) GetUncheckedNotificationCountCalls() []struct {
+	Ctx                 *gin.Context
+	NotificationCntChan chan<- int
+} {
+	var calls []struct {
+		Ctx                 *gin.Context
+		NotificationCntChan chan<- int
+	}
+	mock.lockGetUncheckedNotificationCount.RLock()
+	calls = mock.calls.GetUncheckedNotificationCount
+	mock.lockGetUncheckedNotificationCount.RUnlock()
+	return calls
+}

--- a/handler/service.go
+++ b/handler/service.go
@@ -63,3 +63,7 @@ type GetNotificationService interface {
 type GetNotificationsService interface {
 	GetNotifications(ctx *gin.Context, nextToken, size string) (service.GetNotificationsResponse, error)
 }
+
+type GetUncheckedNotificationCountService interface {
+	GetUncheckedNotificationCount(ctx *gin.Context, notificationCntChan chan<- int) (int, error)
+}

--- a/router/auth_router.go
+++ b/router/auth_router.go
@@ -85,5 +85,9 @@ func SetAuthRouting(ctx context.Context, db *sqlx.DB, router *gin.Engine, cfg *c
 	notificationsHandler := handler.NewGetNotifications(notificationsService)
 	groupRoute.GET("/notifications", notificationsHandler.ServeHTTP)
 
+	uncheckedNotificationCountService := service.NewGetUncheckedNotificationCount(db, cache, rep)
+	uncheckedNotificationsHandler := handler.NewGetUncheckedNotificationCount(uncheckedNotificationCountService)
+	groupRoute.GET("/unchecked_notification_count", uncheckedNotificationsHandler.ServeHTTP)
+
 	return nil
 }

--- a/service/get_unchecked_notification_count.go
+++ b/service/get_unchecked_notification_count.go
@@ -27,20 +27,20 @@ func NewGetUncheckedNotificationCount(db *sqlx.DB, cache domain.Cache, repo *rep
 //
 // @return
 // ユーザ一覧
-func (gn *GetUncheckedNotificationCount) GetUncheckedNotificationCount(ctx *gin.Context, notificationCntChan chan<- int) (int, error) {
+func (gunc *GetUncheckedNotificationCount) GetUncheckedNotificationCount(ctx *gin.Context, notificationCntChan chan<- int) (int, error) {
 	// ユーザID確認
 	u, _ := ctx.Get(auth.UserID)
 	userID := u.(model.UserID)
 
 	// お知らせ数の確認
-	cnt, err := gn.NotifRepo.GetUncheckedNotificationCount(ctx, gn.DB, userID)
+	cnt, err := gunc.NotifRepo.GetUncheckedNotificationCount(ctx, gunc.DB, userID)
 	if err != nil {
 		return 0, fmt.Errorf("faild to get unchecked notification count from db: %w", err)
 	}
 
 	// お知らせ通知をサブスクライブ
 	go func() {
-		payloadChan, err := gn.Cache.Subscribe(ctx, fmt.Sprintf("notification:%d", userID))
+		payloadChan, err := gunc.Cache.Subscribe(ctx, fmt.Sprintf("notification:%d", userID))
 		if err != nil {
 			return
 		}
@@ -50,7 +50,7 @@ func (gn *GetUncheckedNotificationCount) GetUncheckedNotificationCount(ctx *gin.
 				return
 			case <-payloadChan:
 				// お知らせの通知が来たら、お知らせテーブルよりお知らせ数取得
-				cnt, err := gn.NotifRepo.GetUncheckedNotificationCount(ctx, gn.DB, userID)
+				cnt, err := gunc.NotifRepo.GetUncheckedNotificationCount(ctx, gunc.DB, userID)
 				if err != nil {
 					return
 				}

--- a/service/get_unchecked_notification_count.go
+++ b/service/get_unchecked_notification_count.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hack-31/point-app-backend/auth"
+	"github.com/hack-31/point-app-backend/domain"
+	"github.com/hack-31/point-app-backend/domain/model"
+	"github.com/hack-31/point-app-backend/repository"
+	"github.com/jmoiron/sqlx"
+)
+
+type GetUncheckedNotificationCount struct {
+	DB        repository.Queryer
+	Cache     domain.Cache
+	NotifRepo domain.NotificationRepo
+}
+
+func NewGetUncheckedNotificationCount(db *sqlx.DB, cache domain.Cache, repo *repository.Repository) *GetUncheckedNotificationCount {
+	return &GetUncheckedNotificationCount{DB: db, Cache: cache, NotifRepo: repo}
+}
+
+// お知らせ数を確認し、かつ、お知らせ通知をサブスクライブ
+//
+// @params ctx コンテキスト
+//
+// @return
+// ユーザ一覧
+func (gn *GetUncheckedNotificationCount) GetUncheckedNotificationCount(ctx *gin.Context, notificationCntChan chan<- int) (int, error) {
+	// ユーザID確認
+	u, _ := ctx.Get(auth.UserID)
+	userID := u.(model.UserID)
+
+	// お知らせ数の確認
+	cnt, err := gn.NotifRepo.GetUncheckedNotificationCount(ctx, gn.DB, userID)
+	if err != nil {
+		return 0, fmt.Errorf("faild to get unchecked notification count from db: %w", err)
+	}
+
+	// お知らせ通知をサブスクライブ
+	go func() {
+		payloadChan, err := gn.Cache.Subscribe(ctx, fmt.Sprintf("notification:%d", userID))
+		if err != nil {
+			return
+		}
+		for {
+			select {
+			case <-ctx.Request.Context().Done():
+				return
+			case <-payloadChan:
+				// お知らせの通知が来たら、お知らせテーブルよりお知らせ数取得
+				cnt, err := gn.NotifRepo.GetUncheckedNotificationCount(ctx, gn.DB, userID)
+				if err != nil {
+					return
+				}
+				notificationCntChan <- cnt
+			}
+		}
+	}()
+
+	return cnt, nil
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# issue
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #95 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- お知らせ数通知API
  - Redisのpubsubを利用して、チャンネル`notification:[userid]`をサブスクライブすることで、ポイントを送付された時に、通知を受け取り、お知らせ数をレスポンスする
 - ゴルーチンリークが起きないようにキャンセル処理を入れております（キャンセルされない限り、通知をし続けます）

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
一旦テストはパスしてます